### PR TITLE
WIP: Sprint 2 - Google Calendar Events CRUD (Issue #5)

### DIFF
--- a/Features/Calendar/Auth/GoogleCalendarAuth.swift
+++ b/Features/Calendar/Auth/GoogleCalendarAuth.swift
@@ -1,0 +1,178 @@
+import Foundation
+import GoogleSignIn
+import AuthenticationServices
+
+// MARK: - Configuration
+
+/// OAuth 2.0 configuration for Google Calendar.
+/// Replace the client ID and URL scheme with values from your Google Cloud Console project.
+enum GoogleCalendarConfig {
+    /// The OAuth client ID from Google Cloud Console (iOS type).
+    /// Format: `<reverse-domain>.apps.googleusercontent.com`
+    static let clientID = "YOUR_CLIENT_ID.apps.googleusercontent.com"
+
+    /// The URL scheme used for callback during OAuth flow.
+    /// Must match what's registered in the app's Info.plist URL Schemes.
+    static let urlScheme = "com.tempo.app"
+
+    /// Scopes requested from the user.
+    /// https://www.googleapis.com/auth/calendar is the full-read-write scope.
+    static let scopes = [
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/calendar.events"
+    ]
+
+    /// Convenience: build the callback URL scheme string.
+    static var callbackScheme: String { "\(urlScheme)://" }
+}
+
+// MARK: - Auth State
+
+/// Represents the current authentication state.
+enum GoogleAuthState: Equatable {
+    case signedOut
+    case signedIn(email: String, accessToken: String)
+    case signingIn
+    case error(String)
+
+    var isSignedIn: Bool {
+        if case .signedIn = self { return true }
+        return false
+    }
+}
+
+// MARK: - Auth Manager
+
+/// Manages the Google OAuth 2.0 lifecycle: sign-in, token refresh, and sign-out.
+@MainActor
+final class GoogleCalendarAuth: NSObject, ObservableObject {
+    @Published private(set) var state: GoogleAuthState = .signedOut
+    @Published private(set) var currentUserEmail: String?
+
+    /// Shared instance for convenience.
+    static let shared = GoogleCalendarAuth()
+
+    private var presentationAnchor: ASPresentationAnchor?
+    private var currentNonce: String?
+
+    override init() {
+        super.init()
+        // Attempt silent sign-in on launch if tokens are persisted.
+        Task { await attemptSilentSignIn() }
+    }
+
+    // MARK: - Public API
+
+    /// Kicks off the Google OAuth 2.0 authorization flow.
+    /// - Parameter anchor: The window anchor for the sign-in UI.
+    func signIn(anchor: ASPresentationAnchor) async {
+        state = .signingIn
+        presentationAnchor = anchor
+
+        // Generate a random nonce for PKCE.
+        currentNonce = UUID().uuidString
+
+        let config = GIDConfiguration(clientID: GoogleCalendarConfig.clientID)
+        config.spoofEndpoint = nil
+
+        do {
+            let result = try await GIDSignIn.shared.signIn(
+                with: config,
+                presenting: anchor,
+                hint: nil,
+                additionalScopes: GoogleCalendarConfig.scopes
+            )
+
+            let accessToken = result.user.accessToken.tokenString
+            let email = result.user.profile?.email ?? "unknown"
+
+            // Persist tokens.
+            KeychainHelper.save(accessToken, for: .accessToken)
+            if let refreshToken = result.user.refreshToken.tokenString {
+                KeychainHelper.save(refreshToken, for: .refreshToken)
+            }
+            // Expiry is typically 1 hour; store approximate timestamp.
+            let expiry = Date().addingTimeInterval(3600).timeIntervalSince1970
+            KeychainHelper.save(String(Int(expiry)), for: .tokenExpiry)
+            KeychainHelper.save(email, for: .userEmail)
+
+            currentUserEmail = email
+            state = .signedIn(email: email, accessToken: accessToken)
+        } catch {
+            state = .error(error.localizedDescription)
+        }
+    }
+
+    /// Attempts silent sign-in using any previously stored refresh token.
+    func attemptSilentSignIn() async {
+        // Check if we have a stored refresh token.
+        guard let refreshToken = KeychainHelper.load(.refreshToken) else {
+            state = .signedOut
+            return
+        }
+
+        state = .signingIn
+
+        // Restore the previous user if available.
+        if let email = KeychainHelper.load(.userEmail),
+           let storedAccessToken = KeychainHelper.load(.accessToken) {
+            // Verify token isn't expired (with a 5-minute buffer).
+            if let expiry = Double(KeychainHelper.load(.tokenExpiry) ?? ""),
+               Date().timeIntervalSince1970 < expiry - 300 {
+                currentUserEmail = email
+                state = .signedIn(email: email, accessToken: storedAccessToken)
+                return
+            }
+        }
+
+        // Attempt token refresh via GIDSignIn.
+        do {
+            let config = GIDConfiguration(clientID: GoogleCalendarConfig.clientID)
+            let result = try await GIDSignIn.shared.signIn(
+                withPresenting: presentationAnchor ?? ASPresentationAnchor(),
+                configuration: config,
+                additionalScopes: GoogleCalendarConfig.scopes
+            )
+
+            let accessToken = result.user.accessToken.tokenString
+            let email = result.user.profile?.email ?? KeychainHelper.load(.userEmail) ?? "unknown"
+
+            KeychainHelper.save(accessToken, for: .accessToken)
+            let expiry = Date().addingTimeInterval(3600).timeIntervalSince1970
+            KeychainHelper.save(String(Int(expiry)), for: .tokenExpiry)
+            KeychainHelper.save(email, for: .userEmail)
+
+            currentUserEmail = email
+            state = .signedIn(email: email, accessToken: accessToken)
+        } catch {
+            // Refresh failed — clear credentials and return to signed-out.
+            signOut()
+        }
+    }
+
+    /// Returns a valid access token, refreshing if necessary.
+    /// Returns `nil` if the user is not signed in or refresh fails.
+    func getValidAccessToken() async -> String? {
+        guard case .signedIn(_, let token) = state else {
+            await attemptSilentSignIn()
+            if case .signedIn(_, let token) = state { return token }
+            return nil
+        }
+        return token
+    }
+
+    /// Signs the user out and clears all stored credentials.
+    func signOut() {
+        GIDSignIn.shared.signOut()
+        KeychainHelper.clearAll()
+        currentUserEmail = nil
+        state = .signedOut
+    }
+
+    // MARK: - URL Handling
+
+    /// Handle the OAuth callback URL. Call this from `onOpenURL` in your App.
+    func handleURL(_ url: URL) -> Bool {
+        GIDSignIn.shared.handle(url)
+    }
+}

--- a/Features/Calendar/Auth/KeychainHelper.swift
+++ b/Features/Calendar/Auth/KeychainHelper.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Security
+
+/// Helper for securely storing OAuth tokens in the iOS Keychain.
+enum KeychainHelper {
+    private static let service = "com.tempo.app"
+
+    enum Key: String {
+        case accessToken = "google_access_token"
+        case refreshToken = "google_refresh_token"
+        case tokenExpiry = "google_token_expiry"
+        case userEmail = "google_user_email"
+    }
+
+    // MARK: - Save
+
+    static func save(_ value: String, for key: Key) {
+        guard let data = value.data(using: .utf8) else { return }
+        delete(key) // Remove any existing item first
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    // MARK: - Load
+
+    static func load(_ key: Key) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    // MARK: - Delete
+
+    static func delete(_ key: Key) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - Clear all
+
+    static func clearAll() {
+        Key.allCases.forEach { delete($0) }
+    }
+
+    private static var allCases: [Key] {
+        [.accessToken, .refreshToken, .tokenExpiry, .userEmail]
+    }
+}

--- a/Features/Calendar/Auth/README.md
+++ b/Features/Calendar/Auth/README.md
@@ -1,0 +1,86 @@
+# Google Calendar OAuth Setup
+
+## 1. Google Cloud Console Configuration
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) and create a new project (or select an existing one).
+
+2. **Enable the Google Calendar API:**
+   - Navigate to **APIs & Services > Library**
+   - Search for "Google Calendar API"
+   - Click **Enable**
+
+3. **Create OAuth 2.0 credentials (iOS):**
+   - Navigate to **APIs & Services > Credentials**
+   - Click **+ Create Credentials > OAuth client ID**
+   - Application type: **iOS**
+   - Bundle ID: `com.tempo.app`
+   - App Store ID: (optional, leave blank if not published)
+   - Click **Create**
+   - Copy the **Client ID** (format: `xxx.apps.googleusercontent.com`)
+
+4. **Configure the OAuth consent screen:**
+   - Navigate to **APIs & Services > OAuth consent screen**
+   - User type: **External**
+   - Fill in app name, email, etc.
+   - Add scopes: `../auth/calendar`, `../auth/calendar.events`
+   - Add your test users (required for external unpublished apps)
+
+## 2. Update Info.plist
+
+Add the following to your app's `Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>com.tempo.app</string>
+    </array>
+    <key>CFBundleURLName</key>
+    <string>com.tempo.app</string>
+  </dict>
+</array>
+```
+
+## 3. Update Source Code
+
+In `Features/Calendar/Auth/GoogleCalendarAuth.swift`, replace the placeholder:
+
+```swift
+static let clientID = "YOUR_CLIENT_ID.apps.googleusercontent.com"
+```
+
+with your actual OAuth client ID from step 3.
+
+## 4. Configure URL Scheme (SceneDelegate)
+
+In your app's SceneDelegate or App file, handle the OAuth callback:
+
+```swift
+import GoogleSignIn
+
+// In SceneDelegate.scene(_:openURLContexts:)
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let url = URLContexts.first?.url else { return }
+    _ = GoogleCalendarAuth.shared.handleURL(url)
+}
+```
+
+Or in SwiftUI App:
+
+```swift
+import GoogleSignIn
+
+@main
+struct TempoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onOpenURL { url in
+                    _ = GoogleCalendarAuth.shared.handleURL(url)
+                }
+        }
+    }
+}
+```

--- a/Features/Calendar/CalendarViewModel.swift
+++ b/Features/Calendar/CalendarViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftUI
+
+/// ViewModel that bridges CalendarView with the Google Calendar service.
+@MainActor
+final class CalendarViewModel: ObservableObject {
+    @Published var events: [CalendarEvent] = []
+    @Published var calendars: [CalendarListItem] = []
+    @Published var selectedCalendarId: String = "primary"
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var selectedDate: Date = Date()
+
+    private let auth: GoogleCalendarAuth
+    private let calendarService: CalendarService
+
+    init(auth: GoogleCalendarAuth = .shared,
+         calendarService: CalendarService = GoogleCalendarService()) {
+        self.auth = auth
+        self.calendarService = calendarService
+    }
+
+    var isAuthenticated: Bool { auth.state.isSignedIn }
+
+    // MARK: - Load
+
+    func loadEvents(for date: Date) async {
+        guard calendarService.isAuthenticated else {
+            errorMessage = "Not signed in."
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+
+        let calendar = Calendar.current
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: date))!
+        let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)!
+
+        do {
+            events = try await calendarService.fetchEvents(
+                from: startOfMonth,
+                to: endOfMonth,
+                calendarId: selectedCalendarId
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    func loadCalendars() async {
+        guard calendarService.isAuthenticated else { return }
+        do {
+            calendars = try await calendarService.fetchCalendars()
+            if let primary = calendars.first(where: { $0.primary }) {
+                selectedCalendarId = primary.id
+            } else if let first = calendars.first {
+                selectedCalendarId = first.id
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Auth
+
+    func signIn(anchor: ASPresentationAnchor) async {
+        await auth.signIn(anchor: anchor)
+        if auth.state.isSignedIn {
+            await loadCalendars()
+            await loadEvents(for: selectedDate)
+        }
+    }
+
+    func signOut() {
+        auth.signOut()
+        events = []
+        calendars = []
+    }
+}

--- a/Features/Calendar/CalendarViewModel.swift
+++ b/Features/Calendar/CalendarViewModel.swift
@@ -64,6 +64,69 @@ final class CalendarViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Event CRUD
+
+    /// Creates a new event on the selected calendar.
+    func createEvent(title: String, startDate: Date, endDate: Date) async {
+        guard calendarService.isAuthenticated else {
+            errorMessage = "Not signed in."
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let newEvent = try await calendarService.createEvent(
+                title: title,
+                startDate: startDate,
+                endDate: endDate,
+                calendarId: selectedCalendarId
+            )
+            events.append(newEvent)
+            events.sort { $0.startDate < $1.startDate }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    /// Updates an existing event (title and/or dates).
+    func updateEvent(id: String, title: String?, startDate: Date?, endDate: Date?) async {
+        guard calendarService.isAuthenticated else {
+            errorMessage = "Not signed in."
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let update = CalendarEventUpdate(id: id, title: title, startDate: startDate, endDate: endDate)
+            let patched = try await calendarService.patchEvent(update, calendarId: selectedCalendarId)
+            if let idx = events.firstIndex(where: { $0.id == id }) {
+                events[idx] = patched
+            }
+            events.sort { $0.startDate < $1.startDate }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    /// Deletes an event by ID.
+    func deleteEvent(id: String) async {
+        guard calendarService.isAuthenticated else {
+            errorMessage = "Not signed in."
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            try await calendarService.deleteEvent(id: id, calendarId: selectedCalendarId)
+            events.removeAll { $0.id == id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
     // MARK: - Auth
 
     func signIn(anchor: ASPresentationAnchor) async {

--- a/Features/Calendar/Services/CalendarServiceProtocol.swift
+++ b/Features/Calendar/Services/CalendarServiceProtocol.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+// MARK: - Models
+
+struct CalendarEvent: Identifiable, Codable, Equatable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let calendarId: String
+
+    var isAllDay: Bool {
+        Calendar.current.isDate(startDate, inSameDayAs: endDate) && Calendar.current.component(.hour, from: endDate) == 0
+    }
+}
+
+struct CalendarListItem: Identifiable, Codable, Equatable {
+    let id: String
+    let summary: String
+    let primary: Bool
+}
+
+// MARK: - Errors
+
+enum CalendarServiceError: Error, LocalizedError {
+    case notAuthenticated
+    case networkError(Error)
+    case parseError
+    case calendarNotFound
+    case eventNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated: return "User is not authenticated with Google."
+        case .networkError(let e): return "Network error: \(e.localizedDescription)"
+        case .parseError: return "Failed to parse calendar response."
+        case .calendarNotFound: return "Calendar not found."
+        case .eventNotFound: return "Event not found."
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Protocol defining the calendar service interface.
+/// Implement this to provide a real Google Calendar backend or a mock for testing.
+protocol CalendarService: AnyObject {
+    /// Fetches the user's calendar list.
+    func fetchCalendars() async throws -> [CalendarListItem]
+
+    /// Fetches events from the primary calendar within a date range.
+    /// - Parameters:
+    ///   - startDate: Start of the range (inclusive).
+    ///   - endDate: End of the range (inclusive).
+    ///   - calendarId: The calendar ID (use "primary" for the user's main calendar).
+    func fetchEvents(from startDate: Date, to endDate: Date, calendarId: String) async throws -> [CalendarEvent]
+
+    /// Creates a new event.
+    /// - Parameters:
+    ///   - title: Event title.
+    ///   - startDate: Event start.
+    ///   - endDate: Event end.
+    ///   - calendarId: Target calendar ID.
+    func createEvent(title: String, startDate: Date, endDate: Date, calendarId: String) async throws -> CalendarEvent
+
+    /// Deletes an event by ID.
+    func deleteEvent(id: String, calendarId: String) async throws
+
+    /// Whether the service is currently authenticated.
+    var isAuthenticated: Bool { get }
+}

--- a/Features/Calendar/Services/CalendarServiceProtocol.swift
+++ b/Features/Calendar/Services/CalendarServiceProtocol.swift
@@ -66,6 +66,28 @@ protocol CalendarService: AnyObject {
     /// Deletes an event by ID.
     func deleteEvent(id: String, calendarId: String) async throws
 
+    /// Patches (partially updates) an existing event.
+    /// Only non-nil fields in `update` are applied.
+    func patchEvent(_ update: CalendarEventUpdate, calendarId: String) async throws -> CalendarEvent
+
     /// Whether the service is currently authenticated.
     var isAuthenticated: Bool { get }
+}
+
+// MARK: - Event Update Payload
+
+/// Fields that can be optionally updated on an existing event.
+/// All fields are optional — only provided values are sent to the API.
+struct CalendarEventUpdate: Codable, Equatable {
+    var id: String
+    var title: String?
+    var startDate: Date?
+    var endDate: Date?
+
+    init(id: String, title: String? = nil, startDate: Date? = nil, endDate: Date? = nil) {
+        self.id = id
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+    }
 }

--- a/Features/Calendar/Services/GoogleCalendarService.swift
+++ b/Features/Calendar/Services/GoogleCalendarService.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Google Calendar API v3 service implementation using native URLSession.
+final class GoogleCalendarService: CalendarService {
+
+    private let auth: GoogleCalendarAuth
+    private let baseURL = "https://www.googleapis.com/calendar/v3"
+    private let session: URLSession
+
+    var isAuthenticated: Bool { auth.state.isSignedIn }
+
+    init(auth: GoogleCalendarAuth = .shared) {
+        self.auth = auth
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Private Helpers
+
+    private func makeRequest(
+        path: String,
+        queryItems: [URLQueryItem] = [],
+        method: String = "GET",
+        body: Data? = nil
+    ) async throws -> Data {
+        guard let token = await auth.getValidAccessToken() else {
+            throw CalendarServiceError.notAuthenticated
+        }
+
+        var components = URLComponents(string: "\(baseURL)\(path)")!
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = method
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body = body {
+            request.httpBody = body
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CalendarServiceError.networkError(URLError(.badServerResponse))
+        }
+
+        guard 200..<300 ~= httpResponse.statusCode else {
+            throw CalendarServiceError.networkError(
+                NSError(domain: "GoogleCalendarService",
+                        code: httpResponse.statusCode,
+                        userInfo: [NSLocalizedDescriptionKey: "HTTP \(httpResponse.statusCode)"])
+            )
+        }
+
+        return data
+    }
+
+    // MARK: - CalendarService
+
+    func fetchCalendars() async throws -> [CalendarListItem] {
+        let data = try await makeRequest(
+            path: "/users/me/calendarList",
+            queryItems: [URLQueryItem(name: "maxResults", value: "100")]
+        )
+
+        struct Response: Decodable {
+            let items: [CalendarEntry]?
+        }
+        struct CalendarEntry: Decodable {
+            let id: String
+            let summary: String?
+            let primary: Bool?
+
+            enum CodingKeys: String, CodingKey {
+                case id, summary, primary
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                id = try container.decode(String.self, forKey: .id)
+                summary = try container.decodeIfPresent(String.self, forKey: .summary)
+                primary = try container.decodeIfPresent(Bool.self, forKey: .primary)
+            }
+        }
+
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        return (response.items ?? []).map { entry in
+            CalendarListItem(
+                id: entry.id,
+                summary: entry.summary ?? entry.id,
+                primary: entry.primary ?? false
+            )
+        }
+    }
+
+    func fetchEvents(from startDate: Date, to endDate: Date, calendarId: String) async throws -> [CalendarEvent] {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        let queryItems = [
+            URLQueryItem(name: "timeMin", value: isoFormatter.string(from: startDate)),
+            URLQueryItem(name: "timeMax", value: isoFormatter.string(from: endDate)),
+            URLQueryItem(name: "maxResults", value: "250"),
+            URLQueryItem(name: "singleEvents", value: "true"),
+            URLQueryItem(name: "orderBy", value: "startTime")
+        ]
+
+        let data = try await makeRequest(
+            path: "/calendars/\(calendarId)/events",
+            queryItems: queryItems
+        )
+
+        struct EventsResponse: Decodable {
+            let items: [EventEntry]?
+        }
+        struct EventEntry: Decodable {
+            let id: String
+            let summary: String?
+            let start: EventDateTime?
+            let end: EventDateTime?
+        }
+        struct EventDateTime: Decodable {
+            let dateTime: String?   // ISO 8601 datetime for timed events
+            let date: String?        // Date only for all-day events
+            let timeZone: String?
+        }
+
+        let response = try JSONDecoder().decode(EventsResponse.self, from: data)
+        return (response.items ?? []).compactMap { entry in
+            guard let title = entry.summary else { return nil }
+
+            let startStr = entry.start?.dateTime ?? entry.start?.date
+            let endStr = entry.end?.dateTime ?? entry.end?.date
+            guard let start = startStr, let end = endStr else { return nil }
+
+            let startDate: Date
+            let endDate: Date
+
+            if entry.start?.dateTime != nil {
+                // Timed event — parse ISO 8601
+                startDate = isoFormatter.date(from: start) ?? Date(timeIntervalSince1970: 0)
+                endDate = isoFormatter.date(from: end) ?? Date(timeIntervalSince1970: 0)
+            } else {
+                // All-day event — date only (YYYY-MM-DD)
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                dateFormatter.timeZone = TimeZone(identifier: "UTC")
+                startDate = dateFormatter.date(from: start) ?? Date(timeIntervalSince1970: 0)
+                endDate = dateFormatter.date(from: end) ?? Date(timeIntervalSince1970: 0)
+            }
+
+            return CalendarEvent(
+                id: entry.id,
+                title: title,
+                startDate: startDate,
+                endDate: endDate,
+                calendarId: calendarId
+            )
+        }
+    }
+
+    func createEvent(title: String, startDate: Date, endDate: Date, calendarId: String) async throws -> CalendarEvent {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withTimeZoneDetail]
+
+        let eventBody: [String: Any] = [
+            "summary": title,
+            "start": [
+                "dateTime": isoFormatter.string(from: startDate),
+                "timeZone": TimeZone.current.identifier
+            ],
+            "end": [
+                "dateTime": isoFormatter.string(from: endDate),
+                "timeZone": TimeZone.current.identifier
+            ]
+        ]
+
+        let bodyData = try JSONSerialization.data(withJSONObject: eventBody)
+
+        let data = try await makeRequest(
+            path: "/calendars/\(calendarId)/events",
+            method: "POST",
+            body: bodyData
+        )
+
+        struct EventEntry: Decodable {
+            let id: String
+            let summary: String?
+        }
+
+        let entry = try JSONDecoder().decode(EventEntry.self, from: data)
+        return CalendarEvent(
+            id: entry.id,
+            title: entry.summary ?? title,
+            startDate: startDate,
+            endDate: endDate,
+            calendarId: calendarId
+        )
+    }
+
+    func deleteEvent(id: String, calendarId: String) async throws {
+        _ = try await makeRequest(
+            path: "/calendars/\(calendarId)/events/\(id)",
+            method: "DELETE"
+        )
+    }
+}

--- a/Features/Calendar/Services/GoogleCalendarService.swift
+++ b/Features/Calendar/Services/GoogleCalendarService.swift
@@ -165,7 +165,7 @@ final class GoogleCalendarService: CalendarService {
 
     func createEvent(title: String, startDate: Date, endDate: Date, calendarId: String) async throws -> CalendarEvent {
         let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime, .withTimeZoneDetail]
+        isoFormatter.formatOptions = [.withInternetDateTime]
 
         let eventBody: [String: Any] = [
             "summary": title,
@@ -206,6 +206,69 @@ final class GoogleCalendarService: CalendarService {
         _ = try await makeRequest(
             path: "/calendars/\(calendarId)/events/\(id)",
             method: "DELETE"
+        )
+    }
+
+    func patchEvent(_ update: CalendarEventUpdate, calendarId: String) async throws -> CalendarEvent {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        var bodyDict: [String: Any] = [:]
+        if let title = update.title {
+            bodyDict["summary"] = title
+        }
+        if let startDate = update.startDate {
+            bodyDict["start"] = [
+                "dateTime": isoFormatter.string(from: startDate),
+                "timeZone": TimeZone.current.identifier
+            ]
+        }
+        if let endDate = update.endDate {
+            bodyDict["end"] = [
+                "dateTime": isoFormatter.string(from: endDate),
+                "timeZone": TimeZone.current.identifier
+            ]
+        }
+
+        let bodyData = try JSONSerialization.data(withJSONObject: bodyDict)
+
+        // The event ID is encoded in the update payload
+        guard let eventId = update.id else {
+            throw CalendarServiceError.eventNotFound
+        }
+
+        let data = try await makeRequest(
+            path: "/calendars/\(calendarId)/events/\(eventId)",
+            queryItems: [URLQueryItem(name: "fields", value: "id,summary,start,end")],
+            method: "PATCH",
+            body: bodyData
+        )
+
+        struct PatchResponse: Decodable {
+            let id: String
+            let summary: String?
+            let start: EventDateTime?
+            let end: EventDateTime?
+        }
+        struct EventDateTime: Decodable {
+            let dateTime: String?
+            let date: String?
+            let timeZone: String?
+        }
+
+        let entry = try JSONDecoder().decode(PatchResponse.self, from: data)
+
+        let startStr = entry.start?.dateTime ?? entry.start?.date
+        let endStr = entry.end?.dateTime ?? entry.end?.date
+        let startDate = startStr.flatMap { isoFormatter.date(from: $0) } ?? Date()
+        let endDate = endStr.flatMap { isoFormatter.date(from: $0) } ?? Date()
+
+        return CalendarEvent(
+            id: entry.id,
+            title: entry.summary ?? update.title ?? "",
+            startDate: startDate,
+            endDate: endDate,
+            calendarId: calendarId
         )
     }
 }

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.tempo.app</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>com.google.gdt.2.<client-id-hash></string>
+	</array>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,11 @@
 // swift-tools-version: 5.9
 import PackageDescription
-let package = Package(name: "Tempo", platforms: [.iOS(.v17)], products: [])
+let package = Package(
+    name: "Tempo",
+    platforms: [.iOS(.v17)],
+    products: [],
+    dependencies: [
+        .package(url: "https://github.com/google/google-signin-ios-spm", from: "7.0.0"),
+        .package(url: "https://github.com/googleapis/google-apis-ios-sdk", from: "3.0.0"),
+    ]
+)

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,2 @@
+# CocoaPods disabled — using SPM for all dependencies.
+# See project.yml for SPM package configuration.

--- a/Tempo.xcodeproj/project.pbxproj
+++ b/Tempo.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		7B3A92608F3FF118D2306D5A /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA04619AFEFCFAEEDEFDA81 /* KeychainHelperTests.swift */; };
 		A0BBFD2DF4D639D29E469171 /* TempoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3FAAF6EEE4281DFB05494F /* TempoApp.swift */; };
 		E2DDC705B327E579DFAF6EF7 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DD785A26B47DFD9162068 /* CalendarView.swift */; };
+		E50154B2D5CB5399CED3736C /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 94347303F2D1857CA7A1832C /* README.md */; };
+		FD8CC0C036C886F22D08E3A5 /* LocalMockCalendarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26CA6BF4285CB04CAFC7665 /* LocalMockCalendarService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,10 +38,12 @@
 		59C0F9CD71A0E904D65E193B /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		68349F0B540061246800E555 /* GoogleCalendarAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCalendarAuth.swift; sourceTree = "<group>"; };
 		71EA93F9A0D6845F111030FA /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
+		94347303F2D1857CA7A1832C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A588FBF105831FB78AB8EDE1 /* MockCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCalendarService.swift; sourceTree = "<group>"; };
 		AE6263597B3354C508BBC7D4 /* Tempo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Tempo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4541DB43EE8ECD6E2F83DBD /* GoogleCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCalendarService.swift; sourceTree = "<group>"; };
 		B51DD785A26B47DFD9162068 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
+		D26CA6BF4285CB04CAFC7665 /* LocalMockCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMockCalendarService.swift; sourceTree = "<group>"; };
 		D57F97E834A8A30DB9CAE89B /* TempoTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TempoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -60,6 +64,7 @@
 			children = (
 				68349F0B540061246800E555 /* GoogleCalendarAuth.swift */,
 				59C0F9CD71A0E904D65E193B /* KeychainHelper.swift */,
+				94347303F2D1857CA7A1832C /* README.md */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -93,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				4EA04619AFEFCFAEEDEFDA81 /* KeychainHelperTests.swift */,
+				D26CA6BF4285CB04CAFC7665 /* LocalMockCalendarService.swift */,
 				A588FBF105831FB78AB8EDE1 /* MockCalendarService.swift */,
 			);
 			path = TempoTests;
@@ -136,6 +142,7 @@
 			buildConfigurationList = 4FE7A9862C48352D13895373 /* Build configuration list for PBXNativeTarget "Tempo" */;
 			buildPhases = (
 				F8BECD3B83F1BDE402E1832A /* Sources */,
+				99E67F85FA1E5FB50DAA3ABA /* Resources */,
 				01D67FA7CD498405BE72BD2D /* Frameworks */,
 			);
 			buildRules = (
@@ -198,12 +205,24 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		99E67F85FA1E5FB50DAA3ABA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E50154B2D5CB5399CED3736C /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		2FA10C5E5FAA1BCAD0D7DAE4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				7B3A92608F3FF118D2306D5A /* KeychainHelperTests.swift in Sources */,
+				FD8CC0C036C886F22D08E3A5 /* LocalMockCalendarService.swift in Sources */,
 				0457789FD3CFD686F3713E91 /* MockCalendarService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -241,8 +260,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_GENERATION_MODE = GeneratedFile;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -304,7 +322,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -386,7 +404,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -406,8 +424,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_GENERATION_MODE = GeneratedFile;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Tempo.xcodeproj/project.pbxproj
+++ b/Tempo.xcodeproj/project.pbxproj
@@ -7,17 +7,63 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0457789FD3CFD686F3713E91 /* MockCalendarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A588FBF105831FB78AB8EDE1 /* MockCalendarService.swift */; };
+		1FBFC3251EF02552B7F48237 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EA93F9A0D6845F111030FA /* CalendarViewModel.swift */; };
+		4B4AA84EF89E28B02193C99F /* GoogleCalendarAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68349F0B540061246800E555 /* GoogleCalendarAuth.swift */; };
+		4C3624309BEDFA2D7F6E2FCF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 9B720F2FE247802DD0D79F34 /* GoogleSignIn */; };
+		63D1C3CF4F732E84365259D7 /* GoogleCalendarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4541DB43EE8ECD6E2F83DBD /* GoogleCalendarService.swift */; };
+		64D6FA3984595BE74C8F4571 /* CalendarServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F54A5BB1F2FB27DD9A4557F /* CalendarServiceProtocol.swift */; };
+		792211DE89A07B282D5E0804 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C0F9CD71A0E904D65E193B /* KeychainHelper.swift */; };
+		7B3A92608F3FF118D2306D5A /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA04619AFEFCFAEEDEFDA81 /* KeychainHelperTests.swift */; };
 		A0BBFD2DF4D639D29E469171 /* TempoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3FAAF6EEE4281DFB05494F /* TempoApp.swift */; };
 		E2DDC705B327E579DFAF6EF7 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DD785A26B47DFD9162068 /* CalendarView.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		5686D52CB9B7A408A45BB569 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AD30179AB18F679D26066274 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4B1ABCA42D941961C207402;
+			remoteInfo = Tempo;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		0F54A5BB1F2FB27DD9A4557F /* CalendarServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarServiceProtocol.swift; sourceTree = "<group>"; };
 		4C3FAAF6EEE4281DFB05494F /* TempoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempoApp.swift; sourceTree = "<group>"; };
+		4EA04619AFEFCFAEEDEFDA81 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
+		59C0F9CD71A0E904D65E193B /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		68349F0B540061246800E555 /* GoogleCalendarAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCalendarAuth.swift; sourceTree = "<group>"; };
+		71EA93F9A0D6845F111030FA /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
+		A588FBF105831FB78AB8EDE1 /* MockCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCalendarService.swift; sourceTree = "<group>"; };
 		AE6263597B3354C508BBC7D4 /* Tempo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Tempo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4541DB43EE8ECD6E2F83DBD /* GoogleCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCalendarService.swift; sourceTree = "<group>"; };
 		B51DD785A26B47DFD9162068 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
+		D57F97E834A8A30DB9CAE89B /* TempoTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TempoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFrameworksBuildPhase section */
+		01D67FA7CD498405BE72BD2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C3624309BEDFA2D7F6E2FCF /* GoogleSignIn in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
 /* Begin PBXGroup section */
+		1551B1ADB0BFC0400F4092C8 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				68349F0B540061246800E555 /* GoogleCalendarAuth.swift */,
+				59C0F9CD71A0E904D65E193B /* KeychainHelper.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		3FA25A73B8353769DBDA00C8 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -38,14 +84,36 @@
 			isa = PBXGroup;
 			children = (
 				AE6263597B3354C508BBC7D4 /* Tempo.app */,
+				D57F97E834A8A30DB9CAE89B /* TempoTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		5ABE29F9C60E86484C7813E7 /* TempoTests */ = {
+			isa = PBXGroup;
+			children = (
+				4EA04619AFEFCFAEEDEFDA81 /* KeychainHelperTests.swift */,
+				A588FBF105831FB78AB8EDE1 /* MockCalendarService.swift */,
+			);
+			path = TempoTests;
+			sourceTree = "<group>";
+		};
+		622229E13690BF09594700D1 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				0F54A5BB1F2FB27DD9A4557F /* CalendarServiceProtocol.swift */,
+				B4541DB43EE8ECD6E2F83DBD /* GoogleCalendarService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		70FC7CDEE91C337024B93FA8 /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
 				B51DD785A26B47DFD9162068 /* CalendarView.swift */,
+				71EA93F9A0D6845F111030FA /* CalendarViewModel.swift */,
+				1551B1ADB0BFC0400F4092C8 /* Auth */,
+				622229E13690BF09594700D1 /* Services */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -55,6 +123,7 @@
 			children = (
 				3FA25A73B8353769DBDA00C8 /* App */,
 				4B0D3764E3F1D906FC8D75BC /* Features */,
+				5ABE29F9C60E86484C7813E7 /* TempoTests */,
 				551138FD8DA4B1DC4CE1CC90 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -67,15 +136,35 @@
 			buildConfigurationList = 4FE7A9862C48352D13895373 /* Build configuration list for PBXNativeTarget "Tempo" */;
 			buildPhases = (
 				F8BECD3B83F1BDE402E1832A /* Sources */,
+				01D67FA7CD498405BE72BD2D /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Tempo;
+			packageProductDependencies = (
+				9B720F2FE247802DD0D79F34 /* GoogleSignIn */,
+			);
 			productName = Tempo;
 			productReference = AE6263597B3354C508BBC7D4 /* Tempo.app */;
 			productType = "com.apple.product-type.application";
+		};
+		C337B61AC76E84E27EF729D6 /* TempoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 68B3E3DE0818150843E75C44 /* Build configuration list for PBXNativeTarget "TempoTests" */;
+			buildPhases = (
+				2FA10C5E5FAA1BCAD0D7DAE4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A8CC82F224EE8C8583190147 /* PBXTargetDependency */,
+			);
+			name = TempoTests;
+			productName = TempoTests;
+			productReference = D57F97E834A8A30DB9CAE89B /* TempoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -97,25 +186,51 @@
 				en,
 			);
 			mainGroup = 93935E517C8A0946CFCF7B9D;
+			packageReferences = (
+				72008655C0CB12B2F8259835 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				B4B1ABCA42D941961C207402 /* Tempo */,
+				C337B61AC76E84E27EF729D6 /* TempoTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2FA10C5E5FAA1BCAD0D7DAE4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7B3A92608F3FF118D2306D5A /* KeychainHelperTests.swift in Sources */,
+				0457789FD3CFD686F3713E91 /* MockCalendarService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8BECD3B83F1BDE402E1832A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				64D6FA3984595BE74C8F4571 /* CalendarServiceProtocol.swift in Sources */,
 				E2DDC705B327E579DFAF6EF7 /* CalendarView.swift in Sources */,
+				1FBFC3251EF02552B7F48237 /* CalendarViewModel.swift in Sources */,
+				4B4AA84EF89E28B02193C99F /* GoogleCalendarAuth.swift in Sources */,
+				63D1C3CF4F732E84365259D7 /* GoogleCalendarService.swift in Sources */,
+				792211DE89A07B282D5E0804 /* KeychainHelper.swift in Sources */,
 				A0BBFD2DF4D639D29E469171 /* TempoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A8CC82F224EE8C8583190147 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B4B1ABCA42D941961C207402 /* Tempo */;
+			targetProxy = 5686D52CB9B7A408A45BB569 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		2F94FC066E934C1EDF0C22F7 /* Release */ = {
@@ -199,6 +314,26 @@
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
+		};
+		84B60CC7AAE0C71B27EACE2F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tempo.app.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tempo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Tempo";
+			};
+			name = Debug;
 		};
 		A43E8332B4882646B3660D8E /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -289,6 +424,26 @@
 			};
 			name = Debug;
 		};
+		CAF8959E515D8230B945CAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tempo.app.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tempo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Tempo";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -297,6 +452,15 @@
 			buildConfigurations = (
 				C4BB3300C35869F601FE5EED /* Debug */,
 				2F94FC066E934C1EDF0C22F7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		68B3E3DE0818150843E75C44 /* Build configuration list for PBXNativeTarget "TempoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				84B60CC7AAE0C71B27EACE2F /* Debug */,
+				CAF8959E515D8230B945CAB1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -311,6 +475,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		72008655C0CB12B2F8259835 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9B720F2FE247802DD0D79F34 /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 72008655C0CB12B2F8259835 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AD30179AB18F679D26066274 /* Project object */;
 }

--- a/Tempo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tempo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "68aa00e3cba36db2e0a76f54dbc84d1f079d8aa9a19bfa9fce02d6286bd620b7",
+  "pins" : [
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tempo.xcodeproj/xcshareddata/xcschemes/Tempo.xcscheme
+++ b/Tempo.xcodeproj/xcshareddata/xcschemes/Tempo.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B4B1ABCA42D941961C207402"
+               BuildableName = "Tempo.app"
+               BlueprintName = "Tempo"
+               ReferencedContainer = "container:Tempo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B4B1ABCA42D941961C207402"
+            BuildableName = "Tempo.app"
+            BlueprintName = "Tempo"
+            ReferencedContainer = "container:Tempo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C337B61AC76E84E27EF729D6"
+               BuildableName = "TempoTests.xctest"
+               BlueprintName = "TempoTests"
+               ReferencedContainer = "container:Tempo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B4B1ABCA42D941961C207402"
+            BuildableName = "Tempo.app"
+            BlueprintName = "Tempo"
+            ReferencedContainer = "container:Tempo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B4B1ABCA42D941961C207402"
+            BuildableName = "Tempo.app"
+            BlueprintName = "Tempo"
+            ReferencedContainer = "container:Tempo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TempoTests/KeychainHelperTests.swift
+++ b/TempoTests/KeychainHelperTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Tempo
+
+final class KeychainHelperTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Clear before each test to ensure isolation.
+        KeychainHelper.clearAll()
+    }
+
+    override func tearDown() {
+        KeychainHelper.clearAll()
+        super.tearDown()
+    }
+
+    func testSaveAndLoad() {
+        KeychainHelper.save("test_token", for: .accessToken)
+        XCTAssertEqual(KeychainHelper.load(.accessToken), "test_token")
+    }
+
+    func testLoadNonExistent() {
+        XCTAssertNil(KeychainHelper.load(.accessToken))
+        XCTAssertNil(KeychainHelper.load(.refreshToken))
+    }
+
+    func testDelete() {
+        KeychainHelper.save("token", for: .accessToken)
+        KeychainHelper.delete(.accessToken)
+        XCTAssertNil(KeychainHelper.load(.accessToken))
+    }
+
+    func testClearAll() {
+        KeychainHelper.save("access", for: .accessToken)
+        KeychainHelper.save("refresh", for: .refreshToken)
+        KeychainHelper.save("user@example.com", for: .userEmail)
+        KeychainHelper.clearAll()
+        XCTAssertNil(KeychainHelper.load(.accessToken))
+        XCTAssertNil(KeychainHelper.load(.refreshToken))
+        XCTAssertNil(KeychainHelper.load(.userEmail))
+    }
+}

--- a/TempoTests/LocalMockCalendarService.swift
+++ b/TempoTests/LocalMockCalendarService.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// A fully local, no-network CalendarService for UI previews and offline development.
+final class LocalMockCalendarService: CalendarService {
+    var isAuthenticated: Bool = true
+
+    private var events: [CalendarEvent] = []
+    private var calendars: [CalendarListItem] = [
+        CalendarListItem(id: "primary", summary: "Personal", primary: true),
+        CalendarListItem(id: "work", summary: "Work Calendar", primary: false),
+        CalendarListItem(id: "family", summary: "Family", primary: false)
+    ]
+
+    init() {
+        seedEvents()
+    }
+
+    private func seedEvents() {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        // Helper to make dates
+        func date(dayOffset: Int, hour: Int, minute: Int = 0) -> Date {
+            calendar.date(byAdding: DateComponents(day: dayOffset, hour: hour, minute: minute), to: today) ?? today
+        }
+
+        events = [
+            CalendarEvent(id: "local-1", title: "Team Standup", startDate: date(dayOffset: 0, hour: 9), endDate: date(dayOffset: 0, hour: 9, minute: 30), calendarId: "work"),
+            CalendarEvent(id: "local-2", title: "Lunch with Sarah", startDate: date(dayOffset: 0, hour: 12), endDate: date(dayOffset: 0, hour: 13), calendarId: "primary"),
+            CalendarEvent(id: "local-3", title: "Project Review", startDate: date(dayOffset: 1, hour: 14), endDate: date(dayOffset: 1, hour: 15, minute: 30), calendarId: "work"),
+            CalendarEvent(id: "local-4", title: "Gym", startDate: date(dayOffset: 1, hour: 7), endDate: date(dayOffset: 1, hour: 8), calendarId: "primary"),
+            CalendarEvent(id: "local-5", title: "Conference Day 1", startDate: date(dayOffset: 3, hour: 9), endDate: date(dayOffset: 3, hour: 17), calendarId: "work"),
+            CalendarEvent(id: "local-6", title: "Conference Day 2", startDate: date(dayOffset: 4, hour: 9), endDate: date(dayOffset: 4, hour: 17), calendarId: "work"),
+            CalendarEvent(id: "local-7", title: "Family Dinner", startDate: date(dayOffset: 5, hour: 18, minute: 30), endDate: date(dayOffset: 5, hour: 21), calendarId: "family"),
+            CalendarEvent(id: "local-8", title: "All Hands", startDate: date(dayOffset: 7, hour: 10), endDate: date(dayOffset: 7, hour: 11), calendarId: "work"),
+        ]
+    }
+
+    func fetchCalendars() async throws -> [CalendarListItem] {
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s simulated delay
+        return calendars
+    }
+
+    func fetchEvents(from startDate: Date, to endDate: Date, calendarId: String) async throws -> [CalendarEvent] {
+        try await Task.sleep(nanoseconds: 150_000_000) // 0.15s simulated delay
+        return events.filter { event in
+            let matchCalendar = calendarId == "primary" || event.calendarId == calendarId
+            let matchRange = event.startDate >= startDate && event.startDate <= endDate
+            return matchCalendar && matchRange
+        }.sorted { $0.startDate < $1.startDate }
+    }
+
+    func createEvent(title: String, startDate: Date, endDate: Date, calendarId: String) async throws -> CalendarEvent {
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2s simulated delay
+        let event = CalendarEvent(
+            id: "local-\(UUID().uuidString.prefix(8))",
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            calendarId: calendarId
+        )
+        events.append(event)
+        return event
+    }
+
+    func deleteEvent(id: String, calendarId: String) async throws {
+        try await Task.sleep(nanoseconds: 100_000_000)
+        events.removeAll { $0.id == id }
+    }
+
+    func patchEvent(_ update: CalendarEventUpdate, calendarId: String) async throws -> CalendarEvent {
+        try await Task.sleep(nanoseconds: 200_000_000)
+        guard let idx = events.firstIndex(where: { $0.id == update.id }) else {
+            throw CalendarServiceError.eventNotFound
+        }
+        let old = events[idx]
+        let updated = CalendarEvent(
+            id: old.id,
+            title: update.title ?? old.title,
+            startDate: update.startDate ?? old.startDate,
+            endDate: update.endDate ?? old.endDate,
+            calendarId: old.calendarId
+        )
+        events[idx] = updated
+        return updated
+    }
+}
+
+// MARK: - Local Mock Data Tests
+
+import XCTest
+
+final class LocalMockCalendarServiceTests: XCTestCase {
+
+    func testFetchCalendarsReturnsThree() async throws {
+        let mock = LocalMockCalendarService()
+        let calendars = try await mock.fetchCalendars()
+        XCTAssertEqual(calendars.count, 3)
+        XCTAssertTrue(calendars.contains { $0.id == \"primary\" && $0.primary })
+    }
+
+    func testFetchEventsFiltersByDateRange() async throws {
+        let mock = LocalMockCalendarService()
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+
+        let events = try await mock.fetchEvents(from: today, to: tomorrow, calendarId: \"primary\")
+        // Should include events on today and tomorrow in primary calendar
+        XCTAssertTrue(events.allSatisfy { $0.calendarId == \"primary\" })
+    }
+
+    func testCreateEventAddsToList() async throws {
+        let mock = LocalMockCalendarService()
+        let before = try await mock.fetchEvents(from: Date.distantPast, to: Date.distantFuture, calendarId: \"primary\")
+        let beforeCount = before.count
+
+        _ = try await mock.createEvent(
+            title: \"New Event\",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            calendarId: \"primary\"
+        )
+
+        let after = try await mock.fetchEvents(from: Date.distantPast, to: Date.distantFuture, calendarId: \"primary\")
+        XCTAssertEqual(after.count, beforeCount + 1)
+    }
+
+    func testPatchEventUpdatesTitle() async throws {
+        let mock = LocalMockCalendarService()
+        let update = CalendarEventUpdate(id: \"local-1\", title: \"Updated Standup\")
+        let result = try await mock.patchEvent(update, calendarId: \"work\")
+        XCTAssertEqual(result.title, \"Updated Standup\")
+    }
+
+    func testPatchEventNotFoundThrows() async throws {
+        let mock = LocalMockCalendarService()
+        let update = CalendarEventUpdate(id: \"nonexistent\", title: \"Ghost\")
+        do {
+            _ = try await mock.patchEvent(update, calendarId: \"primary\")
+            XCTFail(\"Should throw eventNotFound\")
+        } catch let error as CalendarServiceError {
+            if case .eventNotFound = error { } // Expected
+            else { XCTFail(\"Wrong error: \\(error)\") }
+        }
+    }
+
+    func testDeleteEventRemovesFromList() async throws {
+        let mock = LocalMockCalendarService()
+        let before = try await mock.fetchEvents(from: Date.distantPast, to: Date.distantFuture, calendarId: \"primary\")
+        let beforeIds = Set(before.map { $0.id })
+
+        try await mock.deleteEvent(id: \"local-2\", calendarId: \"primary\")
+
+        let after = try await mock.fetchEvents(from: Date.distantPast, to: Date.distantFuture, calendarId: \"primary\")
+        XCTAssertFalse(after.map { $0.id }.contains(\"local-2\"))
+        XCTAssertEqual(before.count - 1, after.count)
+    }
+}

--- a/TempoTests/MockCalendarService.swift
+++ b/TempoTests/MockCalendarService.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import Tempo
+
+// MARK: - Mock CalendarService
+
+final class MockCalendarService: CalendarService {
+    var isAuthenticated: Bool = true
+
+    var fetchCalendarsResult: Result<[CalendarListItem], Error> = .success([])
+    var fetchEventsResult: Result<[CalendarEvent], Error> = .success([])
+    var createEventResult: Result<CalendarEvent, Error> = .success(CalendarEvent(
+        id: "mock-1", title: "Test Event", startDate: Date(), endDate: Date(), calendarId: "primary"
+    ))
+    var deleteEventResult: Result<Void, Error> = .success(())
+
+    func fetchCalendars() async throws -> [CalendarListItem] {
+        try fetchCalendarsResult.get()
+    }
+
+    func fetchEvents(from: Date, to: Date, calendarId: String) async throws -> [CalendarEvent] {
+        try fetchEventsResult.get()
+    }
+
+    func createEvent(title: String, startDate: Date, endDate: Date, calendarId: String) async throws -> CalendarEvent {
+        try createEventResult.get()
+    }
+
+    func deleteEvent(id: String, calendarId: String) async throws {
+        try deleteEventResult.get()
+    }
+}
+
+// MARK: - Tests
+
+final class CalendarServiceTests: XCTestCase {
+
+    func testCalendarServiceErrorDescriptions() {
+        XCTAssertNotNil(CalendarServiceError.notAuthenticated.errorDescription)
+        XCTAssertNotNil(CalendarServiceError.networkError(NSError(domain: "", code: 0)).errorDescription)
+        XCTAssertNotNil(CalendarServiceError.parseError.errorDescription)
+        XCTAssertNotNil(CalendarServiceError.calendarNotFound.errorDescription)
+        XCTAssertNotNil(CalendarServiceError.eventNotFound.errorDescription)
+    }
+
+    func testMockFetchCalendarsSuccess() async throws {
+        let mock = MockCalendarService()
+        mock.fetchCalendarsResult = .success([
+            CalendarListItem(id: "primary", summary: "Primary Calendar", primary: true)
+        ])
+        let calendars = try await mock.fetchCalendars()
+        XCTAssertEqual(calendars.count, 1)
+        XCTAssertEqual(calendars[0].id, "primary")
+        XCTAssertTrue(calendars[0].primary)
+    }
+
+    func testMockFetchEventsSuccess() async throws {
+        let mock = MockCalendarService()
+        let now = Date()
+        let event = CalendarEvent(id: "e1", title: "Team Sync", startDate: now, endDate: now.addingTimeInterval(3600), calendarId: "primary")
+        mock.fetchEventsResult = .success([event])
+
+        let events = try await mock.fetchEvents(from: now, to: now, calendarId: "primary")
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].title, "Team Sync")
+    }
+
+    func testMockCreateEventSuccess() async throws {
+        let mock = MockCalendarService()
+        let event = try await mock.createEvent(title: "New Event", startDate: Date(), endDate: Date(), calendarId: "primary")
+        XCTAssertEqual(event.title, "Test Event") // From mock default
+    }
+
+    func testMockDeleteEventSuccess() async throws {
+        let mock = MockCalendarService()
+        try await mock.deleteEvent(id: "e1", calendarId: "primary")
+    }
+
+    func testMockFetchCalendarsFailure() async throws {
+        let mock = MockCalendarService()
+        mock.fetchCalendarsResult = .failure(CalendarServiceError.networkError(NSError(domain: "", code: -1)))
+        do {
+            _ = try await mock.fetchCalendars()
+            XCTFail("Expected error")
+        } catch let error as CalendarServiceError {
+            if case .networkError = error { } // Expected
+            else { XCTFail("Wrong error type") }
+        }
+    }
+
+    func testMockFetchEventsFailure() async throws {
+        let mock = MockCalendarService()
+        mock.fetchEventsResult = .failure(CalendarServiceError.notAuthenticated)
+        do {
+            _ = try await mock.fetchEvents(from: Date(), to: Date(), calendarId: "primary")
+            XCTFail("Expected error")
+        } catch let error as CalendarServiceError {
+            if case .notAuthenticated = error { } // Expected
+            else { XCTFail("Wrong error type") }
+        }
+    }
+}
+
+// MARK: - CalendarEvent Tests
+
+final class CalendarEventTests: XCTestCase {
+
+    func testAllDayEventTrue() {
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 6
+        components.day = 15
+        components.hour = 0
+        components.minute = 0
+        let start = Calendar.current.date(from: components)!
+
+        components.hour = 0
+        components.minute = 0
+        let end = Calendar.current.date(from: components)!.addingTimeInterval(-1) // midnight previous day
+
+        // Actually let's test a same-day all-day scenario properly
+        let allDayStart = Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 15))!
+        let allDayEnd = Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 16))!
+        let event = CalendarEvent(id: "1", title: "All Day", startDate: allDayStart, endDate: allDayEnd, calendarId: "primary")
+        XCTAssertTrue(event.isAllDay)
+    }
+
+    func testAllDayEventFalse() {
+        let start = Date()
+        let end = start.addingTimeInterval(3600)
+        let event = CalendarEvent(id: "2", title: "Timed", startDate: start, endDate: end, calendarId: "primary")
+        XCTAssertFalse(event.isAllDay)
+    }
+}

--- a/TempoTests/MockCalendarService.swift
+++ b/TempoTests/MockCalendarService.swift
@@ -12,6 +12,9 @@ final class MockCalendarService: CalendarService {
         id: "mock-1", title: "Test Event", startDate: Date(), endDate: Date(), calendarId: "primary"
     ))
     var deleteEventResult: Result<Void, Error> = .success(())
+    var patchEventResult: Result<CalendarEvent, Error> = .success(CalendarEvent(
+        id: "mock-patched", title: "Patched Event", startDate: Date(), endDate: Date(), calendarId: "primary"
+    ))
 
     func fetchCalendars() async throws -> [CalendarListItem] {
         try fetchCalendarsResult.get()
@@ -27,6 +30,10 @@ final class MockCalendarService: CalendarService {
 
     func deleteEvent(id: String, calendarId: String) async throws {
         try deleteEventResult.get()
+    }
+
+    func patchEvent(_ update: CalendarEventUpdate, calendarId: String) async throws -> CalendarEvent {
+        try patchEventResult.get()
     }
 }
 
@@ -73,6 +80,26 @@ final class CalendarServiceTests: XCTestCase {
     func testMockDeleteEventSuccess() async throws {
         let mock = MockCalendarService()
         try await mock.deleteEvent(id: "e1", calendarId: "primary")
+    }
+
+    func testMockPatchEventSuccess() async throws {
+        let mock = MockCalendarService()
+        let update = CalendarEventUpdate(id: "e1", title: "Updated Title")
+        let result = try await mock.patchEvent(update, calendarId: "primary")
+        XCTAssertEqual(result.title, "Patched Event") // From mock default
+    }
+
+    func testMockPatchEventFailure() async throws {
+        let mock = MockCalendarService()
+        mock.patchEventResult = .failure(CalendarServiceError.eventNotFound)
+        let update = CalendarEventUpdate(id: "nonexistent")
+        do {
+            _ = try await mock.patchEvent(update, calendarId: "primary")
+            XCTFail("Expected error")
+        } catch let error as CalendarServiceError {
+            if case .eventNotFound = error { } // Expected
+            else { XCTFail("Wrong error type: \(error)") }
+        }
     }
 
     func testMockFetchCalendarsFailure() async throws {

--- a/project.yml
+++ b/project.yml
@@ -2,8 +2,26 @@ name: Tempo
 options:
   bundleIdPrefix: com.tempo
   deploymentTarget:
-    iOS: "17.0"
+    iOS: "26.0"
   xcodeVersion: "15.0"
+
+schemes:
+  Tempo:
+    build:
+      targets:
+        Tempo: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - TempoTests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release
 
 packages:
   GoogleSignIn:
@@ -23,7 +41,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tempo.app
-        INFOPLIST_GENERATION_MODE: GeneratedFile
+        INFOPLIST_FILE: Info.plist
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
@@ -31,7 +49,6 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
-        GENERATE_INFOPLIST_FILE: YES
         CODE_SIGN_IDENTITY: ""
         CODE_SIGNING_REQUIRED: NO
         CODE_SIGNING_ALLOWED: NO

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,11 @@ options:
     iOS: "17.0"
   xcodeVersion: "15.0"
 
+packages:
+  GoogleSignIn:
+    url: https://github.com/google/GoogleSignIn-iOS
+    from: "7.0.0"
+
 targets:
   Tempo:
     type: application
@@ -12,6 +17,9 @@ targets:
     sources:
       - path: App
       - path: Features
+    dependencies:
+      - package: GoogleSignIn
+        product: GoogleSignIn
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tempo.app
@@ -24,6 +32,23 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_IDENTITY: ""
+        CODE_SIGNING_REQUIRED: NO
+        CODE_SIGNING_ALLOWED: NO
+
+  TempoTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: TempoTests
+    dependencies:
+      - target: Tempo
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.tempo.app.tests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Tempo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Tempo"
+        BUNDLE_LOADER: "$(TEST_HOST)"
         CODE_SIGN_IDENTITY: ""
         CODE_SIGNING_REQUIRED: NO
         CODE_SIGNING_ALLOWED: NO


### PR DESCRIPTION
## Sprint 2: Google Calendar API v3 Event CRUD (Issue #5)

### Summary
Implements full event lifecycle on top of PR #3 (OAuth). All operations use Google Calendar API v3 REST (no SDK).

### What changed

| File | Change |
|------|--------|
| `Features/Calendar/Services/CalendarServiceProtocol.swift` | Added `patchEvent()` + `CalendarEventUpdate` struct |
| `Features/Calendar/Services/GoogleCalendarService.swift` | Implemented Events:patch API (partial update) |
| `Features/Calendar/CalendarViewModel.swift` | Added `createEvent / updateEvent / deleteEvent` actions |
| `TempoTests/MockCalendarService.swift` | Added `patchEvent` + unit tests |
| `TempoTests/LocalMockCalendarService.swift` | New: rich seeded mock (8 events, 3 calendars) for UI previews |
| `Info.plist` | New: `CFBundleURLTypes` (Google OAuth URL scheme) + `LSApplicationQueriesSchemes` |
| `project.yml` | `deploymentTarget=iOS 26.0`, `INFOPLIST_FILE=Info.plist`, added `schemes:` section |

### APIs implemented
- `GET /calendar/v3/users/me/calendarList` — list calendars
- `GET /calendar/v3/calendars/{id}/events` — list events (date range, singleEvents)
- `POST /calendar/v3/calendars/{id}/events` — create event
- `PATCH /calendar/v3/calendars/{id}/events/{eventId}` — partial update
- `DELETE /calendar/v3/calendars/{id}/events/{eventId}` — delete event

### Build note
Local `xcodebuild` blocked in this environment — Xcode 26.1 beta with no iOS simulator/device runtime installed (`iOS 26.1 is not installed`). Please verify build on a standard CI or dev machine.

### Linked issue
Closes #5
